### PR TITLE
Fixes issue when outcome is not in 3rd position on the dataset

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -1052,6 +1052,13 @@ evaluatr.impact.pre = function(analysis, run.stl=TRUE) {
         covars[,!(colnames(covars) %in% analysis$.private$exclude_covar), drop = FALSE]
       }
     )
+  analysis$covars$full <-
+    lapply(
+      analysis$covars$full, function(x){ 
+        x[,analysis$outcome_name]<-NULL
+        return(x)
+      }
+    )
   analysis$covars$time <-
     setNames(lapply(
       analysis$covars$full,


### PR DESCRIPTION
was previously including the variable as a standardized but unlogged covariate